### PR TITLE
Removed '\n\r' from plain text response

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -290,7 +290,7 @@ class Route {
     // Send response
     const sendResponse = () => {
       response.writeHead(statusCode, headers);
-      response.write(body + '\n\r');
+      response.write(body);
       return response.end();
     };
     if ([401, 403].includes(statusCode)) {

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
     name: 'maka:rest',
     summary: 'Create authenticated REST APIs in Meteor 1.10.2+ via HTTP/HTTPS',
-    version: '2.0.10',
+    version: '2.0.11',
     git: 'https://github.com/maka-io/maka-rest.git'
 });
 


### PR DESCRIPTION
This is related to #5. I think '\n\r' can be added by the user if needed, but also I think it should have been '\r\n' anyway.
Also I incremented version number.